### PR TITLE
Maybe use the starting price as the base?

### DIFF
--- a/src/utilities/monteCarlo.js
+++ b/src/utilities/monteCarlo.js
@@ -12,7 +12,7 @@ export default class MonteCarlo {
     for (let i = 0; i < steps; i += 1) {
       let newPrice = 0;
       while (newPrice <= 0) {
-        newPrice = MonteCarlo.singleIterationStep(price, dailyVolatility);
+        newPrice = MonteCarlo.singleIterationStep(price, dailyVolatility, startPrice);
       }
       iterationValues.push(newPrice);
       price = newPrice;
@@ -26,9 +26,10 @@ export default class MonteCarlo {
    * @param {number} dailyVolatility The potential daily volatility. NOT annual. DAILY.
    * @return {number} The new price
    */
-  static singleIterationStep(lastPrice, dailyVolatility) {
+  static singleIterationStep(lastPrice, dailyVolatility, startPrice) {
     const volatility = MonteCarlo.randomNumber() * dailyVolatility;
-    const price = lastPrice * (1 + volatility);
+    const priceChange = startPrice * (volatility);
+    const price = lastPrice + priceChange;
     return price;
   }
 


### PR DESCRIPTION
This probably is a bad idea...

But basically the population values can end up in a dramatic range by using the previous price as the base. This forces the base of a price change to be the original starting price.

Which means the range of possible outcomes is narrowed... also, I should consider bringing values less than 0 back into the equation for statistical accuracy? Still not sure on that.